### PR TITLE
Handle pe.OptionalHeader32 to avoid panic

### DIFF
--- a/efi/pecoff/checksum.go
+++ b/efi/pecoff/checksum.go
@@ -38,13 +38,16 @@ func PECOFFChecksum(peFile []byte) *PECOFFSigningContext {
 
 	var SizeOfHeaders int64
 	var dd4start int64
+	var ddEntry pe.DataDirectory
 	switch optHeader := f.OptionalHeader.(type) {
 	case *pe.OptionalHeader32:
 		dd4start = offset + 128
 		SizeOfHeaders = int64(optHeader.SizeOfHeaders)
+		ddEntry = optHeader.DataDirectory[4]
 	case *pe.OptionalHeader64:
 		dd4start = offset + 144
 		SizeOfHeaders = int64(optHeader.SizeOfHeaders)
+		ddEntry = optHeader.DataDirectory[4]
 	}
 
 	// Finds where the checksum start
@@ -91,8 +94,8 @@ func PECOFFChecksum(peFile []byte) *PECOFFSigningContext {
 	// lastSection := len(f.Sections) - 1
 	// sectionEnd := f.Sections[lastSection].Offset + f.Sections[lastSection].Size
 	sectionEnd := sectionOffset + sectionSize
-	addr := f.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[4].VirtualAddress
-	certSize := f.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[4].Size
+	addr := ddEntry.VirtualAddress
+	certSize := ddEntry.Size
 
 	if certSize > 0 {
 		hashBuffer.Write(peFile[sectionEnd:addr])

--- a/efi/pecoff/signature.go
+++ b/efi/pecoff/signature.go
@@ -81,15 +81,17 @@ func AppendToBinary(PEFile *PECOFFSigningContext, sig []byte) ([]byte, error) {
 	return pefile, nil
 }
 
-// TODO: Need 32 bit support
 func GetSignatureDataDirectory(pefile []byte) (pe.DataDirectory, error) {
 	buf := bytes.NewReader(pefile)
 	f, err := pe.NewFile(buf)
 	if err != nil {
-		return pe.DataDirectory{}, errors.Wrapf(err, "could parse PE file")
+		return pe.DataDirectory{}, errors.Wrapf(err, "couldn't parse PE file")
 	}
 	defer f.Close()
-	return f.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[4], nil
+	if oh64, ok := f.OptionalHeader.(*pe.OptionalHeader64); ok {
+		return oh64.DataDirectory[4], nil
+	}
+	return f.OptionalHeader.(*pe.OptionalHeader32).DataDirectory[4], nil
 }
 
 // This fetches the attached signature data


### PR DESCRIPTION
`sbctl verify`  panics if ESP path contains a PE32 executable (e.g. BIOS update). Same for `sbctl sign`.

<details>
  <summary>view panic</summary> 

  ```shell
  $ sbctl verify 
  Verifying file database and EFI images in /efi...
  ✔ /efi/EFI/BOOT/BOOTX64.EFI is signed
  ✔ /efi/EFI/Linux/linux-linux.efi is signed
  ✔ /efi/EFI/Linux/linux-lts.efi is signed
  ✔ /efi/EFI/systemd/systemd-bootx64.efi is signed
  panic: interface conversion: interface {} is *pe.OptionalHeader32, not *pe.OptionalHeader64
  
  goroutine 1 [running]:
  github.com/foxboron/go-uefi/efi/pecoff.GetSignatureDataDirectory(0xc000300000, 0x1813f30, 0x1813f31, 0x0, 0x0, 0x0)
	  github.com/foxboron/go-uefi@v0.0.0-20210611230104-7a6a29e36155/efi/pecoff/signature.go:92 +0x1c5
  github.com/foxboron/go-uefi/efi/pecoff.GetSignatureBytesFromFile(0xc000300000, 0x1813f30, 0x1813f31, 0xc0000b2b00, 0x0, 0x0, 0x1, 0xc0000100f0)
	  github.com/foxboron/go-uefi@v0.0.0-20210611230104-7a6a29e36155/efi/pecoff/signature.go:97 +0x45
  github.com/foxboron/go-uefi/efi/pecoff.GetSignatures(0xc000300000, 0x1813f30, 0x1813f31, 0x0, 0x0, 0x0, 0x0, 0xc0000100d8)
	  github.com/foxboron/go-uefi@v0.0.0-20210611230104-7a6a29e36155/efi/pecoff/reader.go:13 +0x5c
  github.com/foxboron/sbctl.VerifyFile(0xc00001c2a0, 0x24, 0xc00001cf00, 0x2b, 0x0, 0x0, 0x0)
	  github.com/foxboron/sbctl/keys.go:149 +0x21d
  main.glob..func10.2(0xc00001cf00, 0x2b, 0x557153c64f18, 0xc000171790, 0x0, 0x0, 0x55715391035d, 0xc000171790)
	  github.com/foxboron/sbctl/cmd/sbctl/verify.go:66 +0xfe
  path/filepath.walk(0xc00001cf00, 0x2b, 0x557153c64f18, 0xc000171790, 0x557153c5b7b0, 0x0, 0x0)
	  path/filepath/path.go:414 +0x457
  path/filepath.walk(0xc000016948, 0x4, 0x557153c64f18, 0xc0001708f0, 0x557153c5b7b0, 0x0, 0x0)
	  path/filepath/path.go:438 +0x31b
  path/filepath.Walk(0xc000016948, 0x4, 0x557153c5b7b0, 0x30, 0xc000167cd8)
	  path/filepath/path.go:501 +0x117
  main.glob..func10(0x557153db2320, 0x557153de5670, 0x0, 0x0, 0x0, 0x0)
	  github.com/foxboron/sbctl/cmd/sbctl/verify.go:47 +0xd5
  github.com/spf13/cobra.(*Command).execute(0x557153db2320, 0x557153de5670, 0x0, 0x0, 0x557153db2320, 0x557153de5670)
	  github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
  github.com/spf13/cobra.(*Command).ExecuteC(0x557153db3220, 0xc000167f60, 0x1, 0x1)
	  github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
  github.com/spf13/cobra.(*Command).Execute(...)
	  github.com/spf13/cobra@v1.1.3/command.go:897
  main.main()
	  github.com/foxboron/sbctl/cmd/sbctl/main.go:69 +0xfb
  ```
</details>