### PR TITLE
add SetAttrOnFile/GetAttrFromFile stub impl.

### DIFF
--- a/efi/attr/attr.go
+++ b/efi/attr/attr.go
@@ -3,8 +3,6 @@ package attr
 import (
 	"errors"
 	"os"
-
-	"golang.org/x/sys/unix"
 )
 
 /* The code below won't work correctly if this tool is built
@@ -66,12 +64,6 @@ func UnsetImmutable(p string) error {
 }
 
 // GetAttr retrieves the attributes of a file on a linux filesystem
-func GetAttrFromFile(f *os.File) (int32, error) {
-	attr_int, err := unix.IoctlGetInt(int(f.Fd()), unix.FS_IOC_GETFLAGS)
-	return int32(attr_int), err
-}
-
-// GetAttr retrieves the attributes of a file on a linux filesystem
 func GetAttr(path string) (int32, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
 	if err != nil {
@@ -79,14 +71,6 @@ func GetAttr(path string) (int32, error) {
 	}
 	defer f.Close()
 	return GetAttrFromFile(f)
-}
-
-// SetAttr sets the attributes of a file on a linux filesystem to the given value
-func SetAttrOnFile(f *os.File, attr int32) error {
-	if err := unix.IoctlSetPointerInt(int(f.Fd()), unix.FS_IOC_SETFLAGS, int(attr)); err != nil {
-		return err
-	}
-	return nil
 }
 
 // SetAttr sets the attributes of a file on a linux filesystem to the given value

--- a/efi/attr/attr_darwin.go
+++ b/efi/attr/attr_darwin.go
@@ -1,0 +1,15 @@
+package attr
+
+import (
+	"os"
+)
+
+// Stub implementation for OSX
+func GetAttrFromFile(f *os.File) (int32, error) {
+	return 0, nil
+}
+
+// Stub implementation for OSX
+func SetAttrOnFile(f *os.File, attr int32) error {
+	return nil
+}

--- a/efi/attr/attr_linux.go
+++ b/efi/attr/attr_linux.go
@@ -1,0 +1,22 @@
+package attr
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetAttr retrieves the attributes of a file on a linux filesystem
+func GetAttrFromFile(f *os.File) (int32, error) {
+	attr_int, err := unix.IoctlGetInt(int(f.Fd()), unix.FS_IOC_GETFLAGS)
+	return int32(attr_int), err
+}
+
+// SetAttr sets the attributes of a file on a linux filesystem to the given value
+func SetAttrOnFile(f *os.File, attr int32) error {
+	if err := unix.IoctlSetPointerInt(int(f.Fd()), unix.FS_IOC_SETFLAGS, int(attr)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Hi.

go-uefi does not build on my M1 Macbook because `unix.FS_IOC_GETFLAGS`/`unix.FS_IOC_SETFLAGS` doesn't exist here. The `IsImmutable` and `UnsetImmutable` functions use that. There is an immutable bit for files on Darwin that can be accessed with chflags() but the code path seems to be only related to reading UEFI vars from sysfs which isn't happening on OSX anyways.

This PR moves the Linux specific code into its own file with the proper build constraint and add a stub implementation for Darwin. Alternatively we would need to change the signature on SetAttrOnFile and GetAttrFromFile because chflags() expects a path, not and fd.