### PR TITLE
Remove unused import

### DIFF
--- a/efi/attr/attr_linux.go
+++ b/efi/attr/attr_linux.go
@@ -1,7 +1,6 @@
 package attr
 
 import (
-	"errors"
 	"os"
 
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
The `errors` package isn't used here. This results in the following build error:

```
# github.com/foxboron/go-uefi/efi/attr
/go/pkg/mod/github.com/foxboron/go-uefi@v0.0.0-20220319124726-e4fa56b6e6c2/efi/attr/attr_linux.go:4:2: imported and not used: "errors"
```
