### PR TITLE
Fix bounds check in pecoff/signature.go

### DIFF
--- a/efi/pecoff/signature.go
+++ b/efi/pecoff/signature.go
@@ -110,7 +110,7 @@ func GetSignatureBytesFromFile(pefile []byte) ([]byte, error) {
 	}
 	addr := datadir.VirtualAddress
 	certSize := datadir.Size
-	if int(addr+certSize) >= len(pefile) {
+	if int(addr+certSize) > len(pefile) {
 		// Most likely a corrupt binary
 		return nil, fmt.Errorf("certificate size exceed the binary file")
 	}


### PR DESCRIPTION
If the signature is at the end of the file while meeting alignment requirements (no padding required), the end of the signature coincides with the end of the file, thus the file should only be considered corrupted if the end of the signature is truly larger than the file but not if it is equal.