### PR TITLE
chore: make the library build on !Linux

### DIFF
--- a/efi/attr/attr_other.go
+++ b/efi/attr/attr_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 package attr
 
 import (


### PR DESCRIPTION
Provide a stub for non-Linux platforms.

This is still useful e.g. to generate key database on non-Linux host.