### PR TITLE
Add missing imports in varsign.go

### DIFF
--- a/efi/signature/varsign.go
+++ b/efi/signature/varsign.go
@@ -2,11 +2,13 @@ package signature
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/binary"
 	"io"
 	"log"
 
 	"github.com/foxboron/go-uefi/efi/util"
+	"github.com/foxboron/go-uefi/pkcs7"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
A recent commit added package references to `varsign.go` but did not update the file with those import statements.

This caused our CI to fail when we imported the updated version of the package.

This adds the missing import statements.