### PR TITLE
authenticode: further reduce memory allocations

### DIFF
--- a/authenticode/authenticode_test.go
+++ b/authenticode/authenticode_test.go
@@ -1,6 +1,7 @@
 package authenticode
 
 import (
+	"bytes"
 	"crypto"
 	"os"
 	"testing"
@@ -12,7 +13,7 @@ func TestVerifyAuthenticode(t *testing.T) {
 	cert, key := asntest.InitCert()
 
 	img := []byte("test")
-	b, err := SignAuthenticode(key, cert, img, crypto.SHA256)
+	b, err := SignAuthenticode(key, cert, bytes.NewReader(img), crypto.SHA256)
 	if err != nil {
 		t.Fatalf("message")
 	}
@@ -21,7 +22,7 @@ func TestVerifyAuthenticode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	ok, err := auth.Verify(cert, img)
+	ok, err := auth.Verify(cert, bytes.NewReader(img))
 	if err != nil {
 		t.Fatalf("failed to verify authenticode checksum: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestCompareOldImplementation(t *testing.T) {
 	}
 
 	img := []byte{0x00, 0x01}
-	bb, err := SignAuthenticode(key, cert, img, crypto.SHA256)
+	bb, err := SignAuthenticode(key, cert, bytes.NewReader(img), crypto.SHA256)
 	if err != nil {
 		t.Fatalf("failed signing digest")
 	}

--- a/authenticode/multireader.go
+++ b/authenticode/multireader.go
@@ -1,0 +1,83 @@
+package authenticode
+
+import (
+	"io"
+	"sort"
+)
+
+// A SizeReaderAt is a ReaderAt with a Size method.
+//
+// An io.SectionReader implements SizeReaderAt.
+type SizeReaderAt interface {
+	Size() int64
+	io.ReaderAt
+}
+
+// newMultiReaderAt is like io.MultiReader but produces a ReaderAt
+// (and Size), instead of just a reader.
+func newMultiReaderAt(parts ...SizeReaderAt) SizeReaderAt {
+	m := &multi{
+		parts: make([]offsetAndSource, 0, len(parts)),
+	}
+	var off int64
+	for _, p := range parts {
+		m.parts = append(m.parts, offsetAndSource{off, p})
+		off += p.Size()
+	}
+	m.size = off
+	return m
+}
+
+type offsetAndSource struct {
+	off int64
+	SizeReaderAt
+}
+
+type multi struct {
+	parts []offsetAndSource
+	size  int64
+}
+
+func (m *multi) Size() int64 { return m.size }
+
+func (m *multi) ReadAt(p []byte, off int64) (n int, err error) {
+	wantN := len(p)
+
+	// Skip past the requested offset.
+	skipParts := sort.Search(len(m.parts), func(i int) bool {
+		// This function returns whether parts[i] will
+		// contribute any bytes to our output.
+		part := m.parts[i]
+		return part.off+part.Size() > off
+	})
+	parts := m.parts[skipParts:]
+
+	// How far to skip in the first part.
+	needSkip := off
+	if len(parts) > 0 {
+		needSkip -= parts[0].off
+	}
+
+	for len(parts) > 0 && len(p) > 0 {
+		readP := p
+		partSize := parts[0].Size()
+		if int64(len(readP)) > partSize-needSkip {
+			readP = readP[:partSize-needSkip]
+		}
+		pn, err0 := parts[0].ReadAt(readP, needSkip)
+		if err0 != nil {
+			return n, err0
+		}
+		n += pn
+		p = p[pn:]
+		if int64(pn)+needSkip == partSize {
+			parts = parts[1:]
+		}
+		needSkip = 0
+	}
+
+	if n != wantN {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}

--- a/cmd/gosiglist/main.go
+++ b/cmd/gosiglist/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -26,7 +25,7 @@ func main() {
 	input := args[0]
 	output := args[1]
 	guid := util.StringToGUID(*owner)
-	b, err := ioutil.ReadFile(input)
+	b, err := os.ReadFile(input)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -34,7 +33,7 @@ func main() {
 	c.AppendBytes(*guid, b)
 	buf := new(bytes.Buffer)
 	signature.WriteSignatureList(buf, *c)
-	err = ioutil.WriteFile(output, buf.Bytes(), 0644)
+	err = os.WriteFile(output, buf.Bytes(), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/gowritevar/main.go
+++ b/cmd/gowritevar/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -14,7 +13,7 @@ func main() {
 		fmt.Println("gowritevar [var] [efi variable]")
 		os.Exit(1)
 	}
-	b, err := ioutil.ReadFile(os.Args[2])
+	b, err := os.ReadFile(os.Args[2])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/efi/device/device_test.go
+++ b/efi/device/device_test.go
@@ -1,8 +1,8 @@
 package device
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,7 +12,7 @@ import (
 func TestAbs(t *testing.T) {
 	dir := "../../tests/data/boot"
 	attributes.Efivars = dir
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/efi/signature/signature_list_test.go
+++ b/efi/signature/signature_list_test.go
@@ -3,7 +3,7 @@ package signature
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,7 +14,7 @@ import (
 
 func ReadTestData(dir string) []string {
 	var paths []string
-	files, _ := ioutil.ReadDir(dir)
+	files, _ := os.ReadDir(dir)
 	for _, file := range files {
 		paths = append(paths, filepath.Join(dir, file.Name()))
 	}
@@ -58,7 +58,7 @@ func TestParseSignatureListVars(t *testing.T) {
 
 func TestParseSignatureListFile(t *testing.T) {
 	for _, path := range SiglistTestFiles {
-		b, _ := ioutil.ReadFile(path)
+		b, _ := os.ReadFile(path)
 		f := bytes.NewReader(b)
 		c, err := ReadSignatureList(f)
 		if err != nil {
@@ -77,7 +77,7 @@ func TestParseSignatureListFile(t *testing.T) {
 
 func TestParseSignatureListHashFile(t *testing.T) {
 	for _, path := range SiglistchecksumTestFiles {
-		b, _ := ioutil.ReadFile(path)
+		b, _ := os.ReadFile(path)
 		f := bytes.NewReader(b)
 		c, err := ReadSignatureList(f)
 		if err != nil {

--- a/efi/signature/varsign.go
+++ b/efi/signature/varsign.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"log"
 
-	"github.com/foxboron/go-uefi/efi/util"
-	"github.com/foxboron/go-uefi/efivar"
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/cryptobyte"
 
+	"github.com/foxboron/go-uefi/efi/util"
+	"github.com/foxboron/go-uefi/efivar"
 	"github.com/foxboron/go-uefi/pkcs7"
-	"github.com/pkg/errors"
 )
 
 // Section 32.2.4 Code Defintiions
@@ -71,7 +71,7 @@ func ReadWinCertificate(f io.Reader) (WINCertificate, error) {
 	return cert, nil
 }
 
-func WriteWinCertificate(b *bytes.Buffer, w *WINCertificate) {
+func WriteWinCertificate(b io.Writer, w *WINCertificate) {
 	for _, d := range []interface{}{w.Length, w.Revision, w.CertType, w.Certificate} {
 		if err := binary.Write(b, binary.LittleEndian, d); err != nil {
 			log.Fatal(err)

--- a/efi/signature/varsign_test.go
+++ b/efi/signature/varsign_test.go
@@ -2,21 +2,21 @@ package signature
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestReadEFIVariableAuthentication2File(t *testing.T) {
 	dir := "../../tests/data/signatures/varsign"
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatal(err)
 	}
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name())
-		b, _ := ioutil.ReadFile(path)
+		b, _ := os.ReadFile(path)
 		f := bytes.NewReader(b)
 		ReadEFIVariableAuthencation2(f)
 	}

--- a/efi/util/certs.go
+++ b/efi/util/certs.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func ReadKey(b []byte) (*rsa.PrivateKey, error) {
@@ -26,7 +26,7 @@ func ReadKey(b []byte) (*rsa.PrivateKey, error) {
 }
 
 func ReadKeyFromFile(path string) (*rsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func ReadCert(b []byte) (*x509.Certificate, error) {
 }
 
 func ReadCertFromFile(path string) (*x509.Certificate, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR (breaking) does those things:
- We no longer read entire binary into the memory. Instead we create a set of `SectionReader`s and store them into the `SizeReaderAt`. This is a breaking change, since it changes the signature of `HashContent` field from `*bytes.Buffer` to `SizeReaderAt`. This is also assumes ownership of the `io.ReaderAt` that we pass to `Parse` as long as the returned `*PECOFFBinary` lives. Fortunately it was already the case, since `lastSection` field assumes that `*PECOFFBinary` will outlive passed `io.ReaderAt`.
- WriteWinCertificate now accepts `io.Writer` instead of a `*bytes.Buffer`. Most of the clients should not notice that.
- `(*Authenticode).Verify` and `SignAuthenticode` now accept `io.Reader` instead of a `[]byte`.
- Updated tests.
- Replaced deprecated `ioutil` with `os` package.

In our project (Talos OS) this changes allowed us to further reduce memory usage from 600 MiB down to 80 MiB