### PR TITLE
Fix incorrect efivar attribute and hex uppercase issue

### DIFF
--- a/efivar/efivar.go
+++ b/efivar/efivar.go
@@ -83,8 +83,7 @@ var (
 
 	// The boot option that was selected for the current boot.
 	BootCurrent = Efivar{"BootCurrent", util.StringToGUID("8be4df61-93ca-11d2-aa0d-00e098032b8c"),
-		attributes.EFI_VARIABLE_NON_VOLATILE |
-			attributes.EFI_VARIABLE_BOOTSERVICE_ACCESS |
+		attributes.EFI_VARIABLE_BOOTSERVICE_ACCESS |
 			attributes.EFI_VARIABLE_RUNTIME_ACCESS}
 
 	// The boot option that was selected for the current boot.

--- a/efivarfs/efivarfs.go
+++ b/efivarfs/efivarfs.go
@@ -102,7 +102,7 @@ func (bo *bootorder) Unmarshal(b *bytes.Buffer) error {
 		sec := make([]byte, 2)
 		b.Read(sec)
 		val := binary.BigEndian.Uint16([]byte{sec[1], sec[0]})
-		*bo = append(*bo, fmt.Sprintf("Boot%04x", val))
+		*bo = append(*bo, fmt.Sprintf("Boot%04X", val))
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/Foxboron/go-uefi/issues/28