### PR TITLE
Add support for Authenticode timestamps

### DIFF
--- a/authenticode/authenticode.go
+++ b/authenticode/authenticode.go
@@ -35,7 +35,7 @@ type Authenticode struct {
 
 // Verify validates an authenticode signature.
 // Note it doesn't validate x509 certificate chains.
-func (a *Authenticode) Verify(cert *x509.Certificate, img io.Reader) (bool, error) {
+func (a *Authenticode) Verify(cert *x509.Certificate, img io.Reader, opts ...pkcs7.VerifyOption) (bool, error) {
 	var h hash.Hash
 	switch {
 	case a.Algid.Algorithm.Equal(pkcs7.OIDDigestAlgorithmSHA256):
@@ -56,7 +56,7 @@ func (a *Authenticode) Verify(cert *x509.Certificate, img io.Reader) (bool, erro
 	if !bytes.Equal(digest, a.Digest) {
 		return false, errors.New("incorrect digest")
 	}
-	return a.Pkcs.Verify(cert)
+	return a.Pkcs.Verify(cert, opts...)
 }
 
 // CreateSpcIndirectDataContent creates the SPCIndirectDataContent container as

--- a/authenticode/checksum.go
+++ b/authenticode/checksum.go
@@ -271,7 +271,7 @@ func (p *PECOFFBinary) Sign(key crypto.Signer, cert *x509.Certificate, opts ...p
 }
 
 // Verify signature
-func (p *PECOFFBinary) Verify(cert *x509.Certificate) (bool, error) {
+func (p *PECOFFBinary) Verify(cert *x509.Certificate, opts ...pkcs7.VerifyOption) (bool, error) {
 	sigs, err := p.Signatures()
 	if err != nil {
 		return false, fmt.Errorf("failed fetching certificates from binary: %w", err)
@@ -285,7 +285,7 @@ func (p *PECOFFBinary) Verify(cert *x509.Certificate) (bool, error) {
 			return false, fmt.Errorf("failed parsing pkcs7 signature from binary: %w", err)
 		}
 
-		ok, err := authcode.Verify(cert, makeSectionReader(p.hashContent))
+		ok, err := authcode.Verify(cert, makeSectionReader(p.hashContent), opts...)
 		if err != nil {
 			return false, err
 		}

--- a/cmd/gosign/main.go
+++ b/cmd/gosign/main.go
@@ -45,6 +45,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	opts := []pkcs7.Option{
+		pkcs7.WithAuthenticodeTimestamp("http://timestamp.digicert.com"),
+	}
+
 	// Check if additional certificates were provided
 	if *addcert != "" {
 		additionalCerts, err := util.ReadCertsFromFile(*addcert)
@@ -59,12 +63,13 @@ func main() {
 				filteredCerts = append(filteredCerts, c)
 			}
 		}
+		opts = append(opts, pkcs7.WithAdditionalCerts(filteredCerts))
 
-		if _, err = file.Sign(Key, Cert, pkcs7.WithAdditionalCerts(filteredCerts)); err != nil {
+		if _, err = file.Sign(Key, Cert, opts...); err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		if _, err := file.Sign(Key, Cert); err != nil {
+		if _, err := file.Sign(Key, Cert, opts...); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/goverify/main.go
+++ b/cmd/goverify/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/foxboron/go-uefi/authenticode"
 	"github.com/foxboron/go-uefi/efi/util"
+	"github.com/foxboron/go-uefi/pkcs7"
 )
 
 func main() {
@@ -24,21 +25,21 @@ func main() {
 
 	peFile, err := os.Open(args[0])
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error opening file: %v", err)
 	}
 	x509Cert, err := util.ReadCertFromFile(*cert)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error reading cert: %v", err)
 	}
 
 	binary, err := authenticode.Parse(peFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error parsing binary: %v", err)
 	}
 
-	ok, err := binary.Verify(x509Cert)
+	ok, err := binary.Verify(x509Cert, pkcs7.VerifyTimestamp(nil))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error verifying signature: %v", err)
 	}
 
 	if !ok {

--- a/cmd/p7verify/main.go
+++ b/cmd/p7verify/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"crypto"
+	"io"
+	"log"
+	"os"
+
+	"github.com/foxboron/go-uefi/pkcs7"
+)
+
+func main() {
+	sigFile, err := os.Open(os.Args[1])
+	if err != nil {
+		log.Fatalf("Failed to open signature file: %v", err)
+	}
+	defer sigFile.Close()
+
+	sigBytes, err := io.ReadAll(sigFile)
+	if err != nil {
+		log.Fatalf("Failed to read signature file: %v", err)
+	}
+
+	pkcs, err := pkcs7.ParsePKCS7(sigBytes)
+	if err != nil {
+		log.Fatalf("Failed to parse PKCS7: %v", err)
+	}
+
+	ok, err := pkcs.Verify(pkcs.Certs[0], pkcs7.VerifyTimestamp(nil))
+	if err != nil {
+		log.Fatalf("Failed to verify signature: %v", err)
+	}
+
+	if !ok {
+		log.Fatalf("Signature verification failed")
+	}
+
+	log.Printf("Signature verification succeeded")
+
+	// now verify timestamp separately
+	attrs := pkcs.SignerInfo[0].UnauthenticatedAttributes
+	if attrs == nil {
+		log.Fatalf("No unauthenticated attributes found, cannot verify timestamp")
+	}
+
+	if len(attrs.TimestampToken) == 0 {
+		log.Fatalf("No timestamp token found in unauthenticated attributes")
+	}
+
+	h := crypto.SHA256.New()
+	h.Write(pkcs.SignerInfo[0].EncryptedDigest) // message imprint inside the timestamp token
+	imprintHash := h.Sum(nil)
+
+	err = pkcs7.VerifyTimestampBytes(attrs.TimestampToken, imprintHash, pkcs.Certs[0])
+	if err != nil {
+		log.Printf("Timestamp signature verification failed: %v", err)
+	}
+
+	log.Printf("Timestamp signature verification succeeded")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/foxboron/go-uefi
 
-go 1.21.0
+go 1.23
+
+toolchain go1.24.3
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/internal/certtest/certtest.go
+++ b/internal/certtest/certtest.go
@@ -158,6 +158,8 @@ func MkCert(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
 		Subject: pkix.Name{
 			Country: []string{"TEST STRING"},
 		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
 	}
 
 	key, err := rsa.GenerateKey(rand.Reader, 4096)

--- a/pkcs7/timestamp.go
+++ b/pkcs7/timestamp.go
@@ -1,0 +1,671 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+
+	encasn1 "encoding/asn1"
+)
+
+// TSAPolicyId represents a timestamp policy identifier
+type TSAPolicyId encasn1.ObjectIdentifier
+
+// TSAQualifier represents a timestamp qualifier
+type TSAQualifier struct {
+	Qualifier string
+}
+
+// MessageImprint contains the hash of the data to be time-stamped
+type MessageImprint struct {
+	HashAlgorithm pkix.AlgorithmIdentifier
+	HashedMessage []byte
+}
+
+// TSAReq represents a Time Stamp Request as defined in RFC 3161
+type TSAReq struct {
+	Version        int
+	MessageImprint MessageImprint
+	ReqPolicy      TSAPolicyId      `asn1:"optional"`
+	Nonce          *big.Int         `asn1:"optional"`
+	CertReq        bool             `asn1:"optional"`
+	Extensions     []pkix.Extension `asn1:"tag:0,optional"`
+}
+
+// CreateTimestampRequest creates a RFC 3161 timestamp request
+func CreateTimestampRequest(messageImprint []byte, hashAlg pkix.AlgorithmIdentifier) (*TSAReq, error) {
+	// Generate a random nonce
+	nonce, err := rand.Int(rand.Reader, big.NewInt(1<<63-1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	req := &TSAReq{
+		Version: 1,
+		MessageImprint: MessageImprint{
+			HashAlgorithm: hashAlg,
+			HashedMessage: messageImprint,
+		},
+		Nonce:   nonce,
+		CertReq: true,
+	}
+
+	return req, nil
+}
+
+// Marshal encodes the TSAReq using cryptobytes
+func (r *TSAReq) Marshal() ([]byte, error) {
+	var b cryptobyte.Builder
+	b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		// version INTEGER
+		b.AddASN1Int64(int64(r.Version))
+
+		// messageImprint MessageImprint
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			// hashAlgorithm AlgorithmIdentifier
+			b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+				b.AddASN1ObjectIdentifier(r.MessageImprint.HashAlgorithm.Algorithm)
+				if len(r.MessageImprint.HashAlgorithm.Parameters.FullBytes) > 0 {
+					b.AddBytes(r.MessageImprint.HashAlgorithm.Parameters.FullBytes)
+				} else {
+					b.AddASN1NULL()
+				}
+			})
+			// hashedMessage OCTET STRING
+			b.AddASN1OctetString(r.MessageImprint.HashedMessage)
+		})
+
+		// reqPolicy TSAPolicyId OPTIONAL
+		if len(r.ReqPolicy) > 0 {
+			b.AddASN1ObjectIdentifier(encasn1.ObjectIdentifier(r.ReqPolicy))
+		}
+
+		// nonce INTEGER OPTIONAL
+		if r.Nonce != nil {
+			b.AddASN1BigInt(r.Nonce)
+		}
+
+		// certReq BOOLEAN DEFAULT FALSE
+		if r.CertReq {
+			b.AddASN1Boolean(r.CertReq)
+		}
+
+		// extensions [0] IMPLICIT Extensions OPTIONAL
+		if len(r.Extensions) > 0 {
+			b.AddASN1(asn1.Tag(0).ContextSpecific().Constructed(), func(b *cryptobyte.Builder) {
+				for _, ext := range r.Extensions {
+					b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+						b.AddASN1ObjectIdentifier(ext.Id)
+						if ext.Critical {
+							b.AddASN1Boolean(ext.Critical)
+						}
+						b.AddASN1OctetString(ext.Value)
+					})
+				}
+			})
+		}
+	})
+
+	return b.Bytes()
+}
+
+// PKIStatus represents the status of a PKI response
+type PKIStatus int
+
+const (
+	PKIStatusGranted                PKIStatus = 0
+	PKIStatusGrantedWithMods        PKIStatus = 1
+	PKIStatusRejection              PKIStatus = 2
+	PKIStatusWaiting                PKIStatus = 3
+	PKIStatusRevocationWarning      PKIStatus = 4
+	PKIStatusRevocationNotification PKIStatus = 5
+)
+
+// PKIFreeText represents free text in a PKI response
+type PKIFreeText []string
+
+// PKIFailureInfo represents failure information
+type PKIFailureInfo encasn1.BitString
+
+// PKIStatus contains the status information of a timestamp response
+type PKIStatusInfo struct {
+	Status       PKIStatus      `asn1:""`
+	StatusString PKIFreeText    `asn1:"optional"`
+	FailInfo     PKIFailureInfo `asn1:"optional"`
+}
+
+// TSAResp represents a Time Stamp Response as defined in RFC 3161
+type TSAResp struct {
+	Status  PKIStatusInfo
+	TSToken []byte // Optional: the timestamp token (PKCS#7 SignedData)
+}
+
+// TSTInfo represents the timestamp info structure
+type TSTInfo struct {
+	Version        int                      `asn1:""`
+	Policy         encasn1.ObjectIdentifier `asn1:""`
+	MessageImprint MessageImprint           `asn1:""`
+	SerialNumber   *big.Int                 `asn1:""`
+	GenTime        time.Time                `asn1:"generalized"`
+	Accuracy       Accuracy                 `asn1:"optional"`
+	Ordering       bool                     `asn1:"optional"`
+	Nonce          *big.Int                 `asn1:"optional"`
+	TSA            []byte                   `asn1:"tag:0,optional"`
+	Extensions     []pkix.Extension         `asn1:"tag:1,optional"`
+}
+
+// Accuracy represents timestamp accuracy
+type Accuracy struct {
+	Seconds int `asn1:"optional"`
+	Millis  int `asn1:"tag:0,optional"`
+	Micros  int `asn1:"tag:1,optional"`
+}
+
+// Marshal encodes the TSTInfo using cryptobytes
+func (t *TSTInfo) Marshal() ([]byte, error) {
+	var b cryptobyte.Builder
+	b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		// version INTEGER
+		b.AddASN1Int64(int64(t.Version))
+
+		// policy OBJECT IDENTIFIER
+		b.AddASN1ObjectIdentifier(t.Policy)
+
+		// messageImprint MessageImprint
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			// hashAlgorithm AlgorithmIdentifier
+			b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+				b.AddASN1ObjectIdentifier(t.MessageImprint.HashAlgorithm.Algorithm)
+				if len(t.MessageImprint.HashAlgorithm.Parameters.FullBytes) > 0 {
+					b.AddBytes(t.MessageImprint.HashAlgorithm.Parameters.FullBytes)
+				} else {
+					b.AddASN1NULL()
+				}
+			})
+			// hashedMessage OCTET STRING
+			b.AddASN1OctetString(t.MessageImprint.HashedMessage)
+		})
+
+		// serialNumber INTEGER
+		b.AddASN1BigInt(t.SerialNumber)
+
+		// genTime GeneralizedTime
+		genTimeStr := t.GenTime.UTC().Format("20060102150405Z")
+		b.AddASN1(asn1.GeneralizedTime, func(b *cryptobyte.Builder) {
+			b.AddBytes([]byte(genTimeStr))
+		})
+
+		// accuracy Accuracy OPTIONAL
+		if t.Accuracy.Seconds != 0 || t.Accuracy.Millis != 0 || t.Accuracy.Micros != 0 {
+			b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+				// seconds INTEGER OPTIONAL
+				if t.Accuracy.Seconds != 0 {
+					b.AddASN1Int64(int64(t.Accuracy.Seconds))
+				}
+				// millis [0] IMPLICIT INTEGER OPTIONAL
+				// For IMPLICIT tags, we write the integer bytes directly with the context-specific tag
+				if t.Accuracy.Millis != 0 {
+					millisBytes := big.NewInt(int64(t.Accuracy.Millis)).Bytes()
+					b.AddASN1(asn1.Tag(0).ContextSpecific(), func(b *cryptobyte.Builder) {
+						b.AddBytes(millisBytes)
+					})
+				}
+				// micros [1] IMPLICIT INTEGER OPTIONAL
+				if t.Accuracy.Micros != 0 {
+					microsBytes := big.NewInt(int64(t.Accuracy.Micros)).Bytes()
+					b.AddASN1(asn1.Tag(1).ContextSpecific(), func(b *cryptobyte.Builder) {
+						b.AddBytes(microsBytes)
+					})
+				}
+			})
+		}
+
+		// ordering BOOLEAN DEFAULT FALSE
+		if t.Ordering {
+			b.AddASN1Boolean(t.Ordering)
+		}
+
+		// nonce INTEGER OPTIONAL
+		if t.Nonce != nil {
+			b.AddASN1BigInt(t.Nonce)
+		}
+
+		// tsa [0] GeneralName OPTIONAL
+		if len(t.TSA) > 0 {
+			b.AddASN1(asn1.Tag(0).ContextSpecific().Constructed(), func(b *cryptobyte.Builder) {
+				b.AddBytes(t.TSA)
+			})
+		}
+
+		// extensions [1] Extensions OPTIONAL
+		if len(t.Extensions) > 0 {
+			b.AddASN1(asn1.Tag(1).ContextSpecific().Constructed(), func(b *cryptobyte.Builder) {
+				for _, ext := range t.Extensions {
+					b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+						b.AddASN1ObjectIdentifier(ext.Id)
+						if ext.Critical {
+							b.AddASN1Boolean(ext.Critical)
+						}
+						b.AddASN1OctetString(ext.Value)
+					})
+				}
+			})
+		}
+	})
+
+	return b.Bytes()
+}
+
+// RequestTimestamp requests a timestamp from a TSA server
+func RequestTimestamp(tsaURL string, req *TSAReq) (*TSAResp, error) {
+	// Marshal the timestamp request
+	reqBytes, err := req.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal timestamp request: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequest("POST", tsaURL, bytes.NewReader(reqBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/timestamp-query")
+	httpReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(reqBytes)))
+
+	// Send request
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send timestamp request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("timestamp server returned status %d", httpResp.StatusCode)
+	}
+
+	// Read response
+	respBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read timestamp response: %w", err)
+	}
+
+	// Parse the TSA response structure using cryptobytes
+	resp, err := parseTSAResp(respBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TSA response: %w", err)
+	}
+
+	// Check status
+	if resp.Status.Status != PKIStatusGranted {
+		return nil, fmt.Errorf("timestamp request rejected with status %d", resp.Status.Status)
+	}
+
+	return resp, nil
+}
+
+// parseTSAResp parses a TSA response using cryptobytes
+func parseTSAResp(data []byte) (*TSAResp, error) {
+	s := cryptobyte.String(data)
+	var respSeq cryptobyte.String
+	if !s.ReadASN1(&respSeq, asn1.SEQUENCE) {
+		return nil, errors.New("failed to read TSAResp SEQUENCE")
+	}
+
+	// Parse PKIStatusInfo
+	var statusSeq cryptobyte.String
+	if !respSeq.ReadASN1(&statusSeq, asn1.SEQUENCE) {
+		return nil, errors.New("failed to read PKIStatusInfo SEQUENCE")
+	}
+
+	var status int64
+	if !statusSeq.ReadASN1Integer(&status) {
+		return nil, errors.New("failed to read status INTEGER")
+	}
+
+	resp := &TSAResp{
+		Status: PKIStatusInfo{
+			Status: PKIStatus(status),
+		},
+	}
+
+	// Optional: statusString (PKIFreeText) - SEQUENCE OF UTF8String
+	if statusSeq.PeekASN1Tag(asn1.SEQUENCE) {
+		var freeTextSeq cryptobyte.String
+		if !statusSeq.ReadASN1(&freeTextSeq, asn1.SEQUENCE) {
+			return nil, errors.New("failed to read PKIFreeText SEQUENCE")
+		}
+		var freeText []string
+		for !freeTextSeq.Empty() {
+			var textBytes []byte
+			if !freeTextSeq.ReadASN1Bytes(&textBytes, asn1.UTF8String) {
+				return nil, errors.New("failed to read UTF8String from PKIFreeText")
+			}
+			freeText = append(freeText, string(textBytes))
+		}
+		resp.Status.StatusString = freeText
+	}
+
+	// Optional: failInfo (PKIFailureInfo) - BIT STRING
+	if statusSeq.PeekASN1Tag(asn1.BIT_STRING) {
+		var failInfo encasn1.BitString
+		if !statusSeq.ReadASN1BitString(&failInfo) {
+			return nil, errors.New("failed to read failInfo BIT STRING")
+		}
+		resp.Status.FailInfo = PKIFailureInfo(failInfo)
+	}
+
+	// Optional: TSToken (timestamp token) - this is a SEQUENCE (ContentInfo)
+	if !respSeq.Empty() {
+		resp.TSToken = []byte(respSeq)
+	}
+
+	return resp, nil
+}
+
+// GetTimestamp requests a timestamp for the given message imprint
+func GetTimestamp(tsaURL string, messageImprint []byte) ([]byte, error) {
+	if tsaURL == "" {
+		return nil, errors.New("TSA URL is required")
+	}
+
+	// Parse URL to validate
+	_, err := url.Parse(tsaURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TSA URL: %w", err)
+	}
+
+	// Create hash algorithm identifier for SHA256
+	hashAlg := pkix.AlgorithmIdentifier{
+		Algorithm:  OIDDigestAlgorithmSHA256,
+		Parameters: encasn1.RawValue{Tag: 5}, // ASN.1 NULL
+	}
+
+	// Create timestamp request
+	req, err := CreateTimestampRequest(messageImprint, hashAlg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create timestamp request: %w", err)
+	}
+
+	// Request timestamp from server
+	resp, err := RequestTimestamp(tsaURL, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request timestamp: %w", err)
+	}
+
+	return resp.TSToken, nil
+}
+
+// VerifyTimestampBytes verifies a RFC 3161 timestamp token and validates it against the provided message imprint.
+// It performs the following verifications:
+//   - Parses the timestampToken as a PKCS#7 signed data structure
+//   - Extracts and validates the TSTInfo (timestamp information)
+//   - Verifies the timestamp generation time is within the signing certificate's validity period
+//   - Confirms the message imprint in the timestamp matches the provided messageImprint
+//   - Validates the TSA certificate chain against trusted roots
+//   - Verifies the timestamp signature using the TSA certificate
+func VerifyTimestampBytes(timestampToken []byte, messageImprint []byte, signerCert *x509.Certificate, opts ...VerifyOption) error {
+	// Parse the timestamp token (which is a PKCS7 signed data structure)
+	token, err := ParsePKCS7(timestampToken)
+	if err != nil {
+		return fmt.Errorf("failed to parse timestamp token: %w", err)
+	}
+
+	// Extract TSTInfo using the proper parsing function that handles OCTET STRING wrapping
+	tstInfo, err := ParseTimestampInfo(token.ContentInfo)
+	if err != nil {
+		return fmt.Errorf("failed to parse TSTInfo: %w", err)
+	}
+
+	// Ensure generation time is present
+	if tstInfo.GenTime.IsZero() {
+		return errors.New("timestamp token has no generation time")
+	}
+
+	// Verify generation time within certificate validity period
+	if tstInfo.GenTime.Before(signerCert.NotBefore) || tstInfo.GenTime.After(signerCert.NotAfter) {
+		return errors.New("timestamp generation time is outside the validity period of the signing certificate")
+	}
+
+	// Verify the message imprint matches
+	if !bytes.Equal(tstInfo.MessageImprint.HashedMessage, messageImprint) {
+		return fmt.Errorf("timestamp message imprint does not match %x vs %x", tstInfo.MessageImprint.HashedMessage, messageImprint)
+	}
+
+	if len(token.Certs) == 0 {
+		return errors.New("no certificates in timestamp token")
+	}
+
+	tsaCert := token.Certs[0]
+
+	c := &VerifyConfig{}
+	for _, optFunc := range opts {
+		optFunc(c)
+	}
+
+	if len(c.TSARoots) > 0 {
+		intermediatePool := x509.NewCertPool()
+		for _, c := range token.Certs[1:] {
+			intermediatePool.AddCert(c)
+		}
+		x509opts := x509.VerifyOptions{
+			Roots:         x509.NewCertPool(),
+			Intermediates: intermediatePool,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		}
+		for _, root := range c.TSARoots {
+			x509opts.Roots.AddCert(root)
+		}
+		if _, err := tsaCert.Verify(x509opts); err != nil {
+			return fmt.Errorf("failed to verify TSA certificate: %w", err)
+		}
+	}
+
+	// Verify the timestamp signature against the TSA certificate
+	ok, err := token.Verify(tsaCert)
+	if err != nil {
+		return fmt.Errorf("failed to verify timestamp signature: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("timestamp signature verification failed")
+	}
+
+	return nil
+}
+
+// ParseTimestampInfo parses and extracts TSTInfo (timestamp token information) from PKCS#7 contentInfo.
+//
+// contentInfo may be the raw ASN.1 encoded content from a PKCS#7 timestamp token, which may be
+// either a TSTInfo structure directly or wrapped in an OCTET STRING
+func ParseTimestampInfo(contentInfo []byte) (*TSTInfo, error) {
+	// Try parsing contentInfo as TSTInfo first
+	tstInfo, err := parseTSTInfo(contentInfo)
+	if err == nil {
+		return tstInfo, nil
+	}
+
+	// The content is wrapped in an OCTET STRING, extract it
+	s := cryptobyte.String(contentInfo)
+	var octetString []byte
+	if !s.ReadASN1Bytes(&octetString, asn1.OCTET_STRING) {
+		return nil, errors.New("failed to parse OCTET STRING wrapper")
+	}
+
+	// Parse the octet string content as TSTInfo
+	tstInfo, err = parseTSTInfo(octetString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TSTInfo from OCTET STRING: %w", err)
+	}
+
+	return tstInfo, nil
+}
+
+// parseTSTInfo parses TSTInfo structure using cryptobytes
+func parseTSTInfo(data []byte) (*TSTInfo, error) {
+	s := cryptobyte.String(data)
+	var tstSeq cryptobyte.String
+	if !s.ReadASN1(&tstSeq, asn1.SEQUENCE) {
+		return nil, errors.New("failed to read TSTInfo SEQUENCE")
+	}
+
+	var tstInfo TSTInfo
+
+	// version INTEGER
+	var version int64
+	if !tstSeq.ReadASN1Integer(&version) {
+		return nil, errors.New("failed to read version")
+	}
+	tstInfo.Version = int(version)
+
+	// policy OBJECT IDENTIFIER
+	if !tstSeq.ReadASN1ObjectIdentifier(&tstInfo.Policy) {
+		return nil, errors.New("failed to read policy OID")
+	}
+
+	// messageImprint MessageImprint
+	var msgImprintSeq cryptobyte.String
+	if !tstSeq.ReadASN1(&msgImprintSeq, asn1.SEQUENCE) {
+		return nil, errors.New("failed to read MessageImprint SEQUENCE")
+	}
+
+	// Parse MessageImprint: hashAlgorithm and hashedMessage
+	hashAlg, err := ParseAlgorithmIdentifier(&msgImprintSeq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse hash algorithm: %w", err)
+	}
+	tstInfo.MessageImprint.HashAlgorithm = *hashAlg
+
+	if !msgImprintSeq.ReadASN1Bytes(&tstInfo.MessageImprint.HashedMessage, asn1.OCTET_STRING) {
+		return nil, errors.New("failed to read hashedMessage")
+	}
+
+	// serialNumber INTEGER
+	tstInfo.SerialNumber = new(big.Int)
+	if !tstSeq.ReadASN1Integer(tstInfo.SerialNumber) {
+		return nil, errors.New("failed to read serialNumber")
+	}
+
+	// genTime GeneralizedTime
+	var genTimeBytes []byte
+	if !tstSeq.ReadASN1Bytes(&genTimeBytes, asn1.GeneralizedTime) {
+		return nil, errors.New("failed to read genTime")
+	}
+	genTime, err := time.Parse("20060102150405Z", string(genTimeBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse genTime: %w", err)
+	}
+	tstInfo.GenTime = genTime
+
+	// Optional fields
+	// accuracy Accuracy OPTIONAL
+	if tstSeq.PeekASN1Tag(asn1.SEQUENCE) {
+		var accSeq cryptobyte.String
+		if !tstSeq.ReadASN1(&accSeq, asn1.SEQUENCE) {
+			return nil, errors.New("failed to read Accuracy SEQUENCE")
+		}
+
+		// All fields in Accuracy are optional
+		// seconds INTEGER OPTIONAL
+		if accSeq.PeekASN1Tag(asn1.INTEGER) {
+			var seconds int64
+			if !accSeq.ReadASN1Integer(&seconds) {
+				return nil, errors.New("failed to read accuracy seconds")
+			}
+			tstInfo.Accuracy.Seconds = int(seconds)
+		}
+
+		// millis [0] IMPLICIT INTEGER (1..999) OPTIONAL
+		// With IMPLICIT tagging, the tag replaces INTEGER tag, so we read bytes directly
+		if accSeq.PeekASN1Tag(asn1.Tag(0).ContextSpecific()) {
+			var millisBytes []byte
+			if !accSeq.ReadASN1Bytes(&millisBytes, asn1.Tag(0).ContextSpecific()) {
+				return nil, errors.New("failed to read accuracy millis")
+			}
+			tstInfo.Accuracy.Millis = int(new(big.Int).SetBytes(millisBytes).Int64())
+		}
+
+		// micros [1] IMPLICIT INTEGER (1..999) OPTIONAL
+		// With IMPLICIT tagging, the tag replaces INTEGER tag, so we read bytes directly
+		if accSeq.PeekASN1Tag(asn1.Tag(1).ContextSpecific()) {
+			var microsBytes []byte
+			if !accSeq.ReadASN1Bytes(&microsBytes, asn1.Tag(1).ContextSpecific()) {
+				return nil, errors.New("failed to read accuracy micros")
+			}
+			tstInfo.Accuracy.Micros = int(new(big.Int).SetBytes(microsBytes).Int64())
+		}
+	}
+
+	// ordering BOOLEAN DEFAULT FALSE
+	if tstSeq.PeekASN1Tag(asn1.BOOLEAN) {
+		if !tstSeq.ReadASN1Boolean(&tstInfo.Ordering) {
+			return nil, errors.New("failed to read ordering")
+		}
+	}
+
+	// nonce INTEGER OPTIONAL
+	if tstSeq.PeekASN1Tag(asn1.INTEGER) {
+		tstInfo.Nonce = new(big.Int)
+		if !tstSeq.ReadASN1Integer(tstInfo.Nonce) {
+			return nil, errors.New("failed to read nonce")
+		}
+	}
+
+	// tsa [0] GeneralName OPTIONAL
+	if tstSeq.PeekASN1Tag(asn1.Tag(0).ContextSpecific().Constructed()) {
+		var tsaBytes cryptobyte.String
+		if !tstSeq.ReadASN1(&tsaBytes, asn1.Tag(0).ContextSpecific().Constructed()) {
+			return nil, errors.New("failed to read tsa")
+		}
+		tstInfo.TSA = []byte(tsaBytes)
+	}
+
+	// extensions [1] Extensions OPTIONAL
+	if tstSeq.PeekASN1Tag(asn1.Tag(1).ContextSpecific().Constructed()) {
+		var extSeq cryptobyte.String
+		if !tstSeq.ReadASN1(&extSeq, asn1.Tag(1).ContextSpecific().Constructed()) {
+			return nil, errors.New("failed to read extensions")
+		}
+
+		for !extSeq.Empty() {
+			var ext pkix.Extension
+			var extBytes cryptobyte.String
+			if !extSeq.ReadASN1(&extBytes, asn1.SEQUENCE) {
+				return nil, errors.New("failed to read extension SEQUENCE")
+			}
+
+			if !extBytes.ReadASN1ObjectIdentifier(&ext.Id) {
+				return nil, errors.New("failed to read extension OID")
+			}
+
+			// Optional critical field
+			if extBytes.PeekASN1Tag(asn1.BOOLEAN) {
+				if !extBytes.ReadASN1Boolean(&ext.Critical) {
+					return nil, errors.New("failed to read extension critical")
+				}
+			}
+
+			if !extBytes.ReadASN1Bytes(&ext.Value, asn1.OCTET_STRING) {
+				return nil, errors.New("failed to read extension value")
+			}
+
+			tstInfo.Extensions = append(tstInfo.Extensions, ext)
+		}
+	}
+
+	return &tstInfo, nil
+}

--- a/pkcs7/timestamp_test.go
+++ b/pkcs7/timestamp_test.go
@@ -1,0 +1,333 @@
+package pkcs7
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509/pkix"
+	encasn1 "encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/foxboron/go-uefi/internal/certtest"
+)
+
+func TestCreateTimestampRequest(t *testing.T) {
+	messageImprint := []byte("test message")
+	hashAlg := pkix.AlgorithmIdentifier{
+		Algorithm:  OIDDigestAlgorithmSHA256,
+		Parameters: encasn1.RawValue{Tag: 5}, // ASN.1 NULL
+	}
+
+	req, err := CreateTimestampRequest(messageImprint, hashAlg)
+	if err != nil {
+		t.Fatalf("Failed to create timestamp request: %v", err)
+	}
+
+	if req.Version != 1 {
+		t.Errorf("Expected version 1, got %d", req.Version)
+	}
+
+	if !req.MessageImprint.HashAlgorithm.Algorithm.Equal(OIDDigestAlgorithmSHA256) {
+		t.Errorf("Hash algorithm mismatch")
+	}
+
+	if string(req.MessageImprint.HashedMessage) != string(messageImprint) {
+		t.Errorf("Message imprint mismatch")
+	}
+
+	if req.Nonce == nil {
+		t.Errorf("Expected nonce to be set")
+	}
+
+	if !req.CertReq {
+		t.Errorf("Expected certificate request to be true")
+	}
+}
+
+func TestParseTimestampInfo(t *testing.T) {
+	// Tests ParseTimestampInfo() function with various inputs (invalid and valid).
+	// The timestamp token creation in the happy path is setup, not the test itself -
+	// the actual test is whether ParseTimestampInfo() correctly parses the TSTInfo.
+
+	// Test with invalid timestamp token
+	invalidToken := []byte("invalid token")
+	_, err := ParseTimestampInfo(invalidToken)
+	if err == nil {
+		t.Errorf("Expected error for invalid timestamp token")
+	}
+
+	// Test with empty token
+	_, err = ParseTimestampInfo([]byte{})
+	if err == nil {
+		t.Errorf("Expected error for empty timestamp token")
+	}
+
+	// Test with valid PKCS7 but invalid TSTInfo content
+	cert, key := certtest.MkCert(t)
+	invalidContent := []byte("not a valid TSTInfo structure")
+	validPKCS7WithInvalidContent, err := SignPKCS7(key, cert, OIDAttributeTSTInfo, invalidContent)
+	if err != nil {
+		t.Fatalf("Failed to create test PKCS7: %v", err)
+	}
+
+	parsedPKCS7, err := ParsePKCS7(validPKCS7WithInvalidContent)
+	if err != nil {
+		t.Fatalf("Failed to parse test PKCS7: %v", err)
+	}
+
+	_, err = ParseTimestampInfo(parsedPKCS7.ContentInfo)
+	if err == nil {
+		t.Errorf("Expected error for invalid TSTInfo content")
+	}
+
+	messageImprint := []byte("test message imprint")
+	hashAlg := pkix.AlgorithmIdentifier{
+		Algorithm:  OIDDigestAlgorithmSHA256,
+		Parameters: encasn1.RawValue{Tag: 5}, // ASN.1 NULL
+	}
+
+	tstInfo := TSTInfo{
+		Version: 1,
+		Policy:  encasn1.ObjectIdentifier{1, 2, 3, 4},
+		MessageImprint: MessageImprint{
+			HashAlgorithm: hashAlg,
+			HashedMessage: messageImprint,
+		},
+		SerialNumber: big.NewInt(12345),
+		GenTime:      time.Now().UTC(),
+	}
+
+	tstInfoBytes, err := tstInfo.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal TSTInfo: %v", err)
+	}
+
+	signedToken, err := SignPKCS7(key, cert, OIDAttributeTSTInfo, tstInfoBytes)
+	if err != nil {
+		t.Fatalf("Failed to create valid PKCS7: %v", err)
+	}
+
+	parsedToken, err := ParsePKCS7(signedToken)
+	if err != nil {
+		t.Fatalf("Failed to parse valid PKCS7: %v", err)
+	}
+
+	parsedInfo, err := ParseTimestampInfo(parsedToken.ContentInfo)
+	if err != nil {
+		t.Fatalf("Expected no error for valid timestamp token, got: %v", err)
+	}
+
+	if parsedInfo.Version != 1 {
+		t.Fatalf("Expected version 1, got %d", parsedInfo.Version)
+	}
+
+	if !bytes.Equal(parsedInfo.MessageImprint.HashedMessage, messageImprint) {
+		t.Fatalf("Message imprint mismatch")
+	}
+}
+
+func TestGetTimestampValidation(t *testing.T) {
+	// Test with empty URL
+	_, err := GetTimestamp("", []byte("test"))
+	if err == nil {
+		t.Errorf("Expected error for empty TSA URL")
+	}
+
+	// Test with invalid URL
+	_, err = GetTimestamp("invalid-url", []byte("test"))
+	if err == nil {
+		t.Errorf("Expected error for invalid TSA URL")
+	}
+
+	// Test with malformed URL that would fail parsing
+	_, err = GetTimestamp("://malformed", []byte("test"))
+	if err == nil {
+		t.Errorf("Expected error for malformed TSA URL")
+	}
+}
+
+func TestRealTimestampRequest(t *testing.T) {
+	// Skip this test in short mode or CI environments
+	if testing.Short() {
+		t.Skip("Skipping real timestamp request test in short mode")
+	}
+
+	// Create a test message imprint (hash of some data)
+	testData := []byte("This is test data for timestamp verification")
+	h := crypto.SHA256.New()
+	h.Write(testData)
+	messageImprint := h.Sum(nil)
+
+	// Request a timestamp from DigiCert's TSA
+	tsaURL := "http://timestamp.digicert.com"
+	timestampToken, err := GetTimestamp(tsaURL, messageImprint)
+	if err != nil {
+		t.Fatalf("Failed to get timestamp from %s: %v", tsaURL, err)
+	}
+
+	if len(timestampToken) == 0 {
+		t.Errorf("Expected non-empty timestamp token")
+	}
+
+	token, err := ParsePKCS7(timestampToken)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp token as pkcs7: %v", err)
+	}
+
+	// Parse the timestamp token to validate its structure
+	tstInfo, err := ParseTimestampInfo(token.ContentInfo)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp token: %v", err)
+	}
+
+	// Verify the message imprint matches
+	if !bytes.Equal(tstInfo.MessageImprint.HashedMessage, messageImprint) {
+		t.Errorf("Timestamp message imprint does not match original")
+	}
+
+	// Verify the timestamp is recent (within the last hour)
+	now := time.Now()
+	if tstInfo.GenTime.After(now) || tstInfo.GenTime.Before(now.Add(-time.Hour)) {
+		t.Errorf("Timestamp time %v is not within expected range (last hour from %v)", tstInfo.GenTime, now)
+	}
+}
+
+func TestSignPKCS7WithTimestamp(t *testing.T) {
+	// Skip this test in short mode or CI environments
+	if testing.Short() {
+		t.Skip("Skipping PKCS7 with timestamp test in short mode")
+	}
+
+	cert, key := certtest.MkCert(t)
+	content := []byte("test content for timestamped signature")
+
+	// Sign with timestamp
+	tsaURL := "http://timestamp.digicert.com"
+	sig, err := SignPKCS7(key, cert, OIDData, content, WithAuthenticodeTimestamp(tsaURL))
+	if err != nil {
+		t.Fatalf("Failed to sign with timestamp: %v", err)
+	}
+
+	// Parse the PKCS7 signature
+	pkcs, err := ParsePKCS7(sig)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamped PKCS7: %v", err)
+	}
+
+	// Verify the signature
+	ok, err := pkcs.Verify(cert)
+	if err != nil {
+		t.Fatalf("Failed to verify timestamped signature: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Timestamped signature verification failed")
+	}
+
+	// Check that the timestamp token is present in unauthenticated attributes
+	if len(pkcs.SignerInfo) == 0 {
+		t.Fatalf("No signer info found")
+	}
+
+	attrs := pkcs.SignerInfo[0].UnauthenticatedAttributes
+	if attrs == nil {
+		t.Fatalf("No unauthenticated attributes found")
+	}
+
+	if len(attrs.TimestampToken) == 0 {
+		t.Fatalf("No timestamp token found in unauthenticated attributes")
+	}
+
+	token, err := ParsePKCS7(attrs.TimestampToken)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp token as pkcs7: %v", err)
+	}
+
+	// Parse the embedded timestamp token
+	tstInfo, err := ParseTimestampInfo(token.ContentInfo)
+	if err != nil {
+		t.Fatalf("Failed to parse embedded timestamp token: %v", err)
+	}
+
+	// Verify the timestamp is recent
+	now := time.Now()
+	if tstInfo.GenTime.After(now) || tstInfo.GenTime.Before(now.Add(-time.Hour)) {
+		t.Errorf("Embedded timestamp time %v is not within expected range", tstInfo.GenTime)
+	}
+
+	h := crypto.SHA256.New()
+	h.Write(pkcs.SignerInfo[0].EncryptedDigest) // message imprint inside the timestamp token
+	err = VerifyTimestampBytes(attrs.TimestampToken, h.Sum(nil), pkcs.Certs[0])
+	if err != nil {
+		t.Fatalf("Failed to verify embedded timestamp token: %v", err)
+	}
+}
+
+func TestVerifyTimestampValidation(t *testing.T) {
+	cert, key := certtest.MkCert(t)
+
+	// Create invalid timestamp token
+	invalidToken := []byte("invalid token")
+	messageImprint := []byte("test message")
+
+	err := VerifyTimestampBytes(invalidToken, messageImprint, cert)
+	if err == nil {
+		t.Errorf("Expected error for invalid timestamp token")
+	}
+
+	// Test with empty trusted certificates
+	validToken, err := SignPKCS7(key, cert, OIDData, []byte("test"))
+	if err != nil {
+		t.Fatalf("Failed to create test token: %v", err)
+	}
+
+	err = VerifyTimestampBytes(validToken, messageImprint, nil)
+	if err == nil {
+		t.Errorf("Expected error for empty trusted certificates")
+	}
+
+	// Happy path: Create valid timestamp token and verify it successfully
+	testData := []byte("data to be timestamped")
+	h := crypto.SHA256.New()
+	h.Write(testData)
+	validMessageImprint := h.Sum(nil)
+
+	hashAlg := pkix.AlgorithmIdentifier{
+		Algorithm:  OIDDigestAlgorithmSHA256,
+		Parameters: encasn1.RawValue{Tag: 5},
+	}
+
+	tstInfo := TSTInfo{
+		Version: 1,
+		Policy:  encasn1.ObjectIdentifier{1, 2, 3, 4},
+		MessageImprint: MessageImprint{
+			HashAlgorithm: hashAlg,
+			HashedMessage: validMessageImprint,
+		},
+		SerialNumber: big.NewInt(99999),
+		GenTime:      time.Now().UTC(),
+	}
+
+	tstInfoBytes, err := tstInfo.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal TSTInfo: %v", err)
+	}
+
+	validTimestampToken, err := SignPKCS7(key, cert, OIDAttributeTSTInfo, tstInfoBytes)
+	if err != nil {
+		t.Fatalf("Failed to create valid timestamp token: %v", err)
+	}
+
+	// Verify the timestamp token with correct message imprint and trusted cert
+	err = VerifyTimestampBytes(validTimestampToken, validMessageImprint, cert)
+	if err != nil {
+		t.Errorf("Expected no error for valid timestamp verification, got: %v", err)
+	}
+
+	// Verify that verification fails with wrong message imprint
+	wrongImprint := []byte("wrong message imprint")
+	err = VerifyTimestampBytes(validTimestampToken, wrongImprint, cert)
+	if err == nil {
+		t.Errorf("Expected error when verifying with wrong message imprint")
+	}
+}


### PR DESCRIPTION
This PR adds support for embedding RFC3161 Timestamps in Authenticode signatures.

* Implement RFC 3161 timestamp request/response handling with TSA server integration
* Add `WithAuthenticodeTimestamp()` option for signing
* Add `VerifyTimestamp()` option to verify timestamps when signing certificates are expired
* Parse unauthenticated attributes (tag 1) to extract timestamp tokens from existing signatures
* Timestamp verification validates generation time against certificate validity period when signer certificate has expired
* Maintains backward compatibility with existing signing/verification workflows

Tested against osslsigncode and sbverify to assure we're producing correctly formatted binaries. I also took the liberty of splitting up pkcs7.go into a couple different files to keep things better organized.